### PR TITLE
Minor fixes on dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Dependencies :
 ```sh
-yay -S  polkit-kde-agent dunst grim rofi rofi-emoji \
+paru --needed -S polkit-kde-agent dunst grim rofi rofi-emoji \
 wl-clipboard wf-recorder hyprpicker-git hyprpaper-git \
 xdg-desktop-portal-hyprland-git ffmpegthumbnailer tumbler  \
 swaylock-effects qt5-wayland qt6-wayland ripgrep  \
@@ -24,7 +24,7 @@ waybar-hyprland-git
 ```
 ### Fonts :
 ```sh
-yay -S ttf-jetbrains-mono ttf-jetbrains-mono-nerd noto-font-emoji
+paru --needed -S ttf-jetbrains-mono ttf-jetbrains-mono-nerd noto-fonts-emoji
 
 ```
 


### PR DESCRIPTION
1. noto-font-emoji is not a correct package name in aur.
2. --needed will skip what is already installed. However, for AUR packages, yay does not support it. So use paru, etc, instead.